### PR TITLE
Skip new test on k8s

### DIFF
--- a/baras/commands.go
+++ b/baras/commands.go
@@ -38,6 +38,8 @@ var _ = Describe("setting_process_commands", func() {
 	})
 
 	Describe("when a buildpack doesn't return process types with start commands", func() {
+		SkipOnK8s("the fix made which introduced this test hasn't been made on cf-for-k8s yet")
+
 		BeforeEach(func() {
 			By("Creating an app")
 			appGUID = CreateApp(appName, spaceGUID, "{}")


### PR DESCRIPTION
The changes in CCNG which now allows staging to sometimes succeed when buildpack doesn't return process types only resolve that issue for CF-for-VMs

Specifically, cf-for-k8s needs to make changes to `cf-api-controllers` which handles the analog of what the staging completion handler does (which is where the fix in CCNG was made)