### PR TITLE
Added a test to check if server name is not leaked

### DIFF
--- a/baras/nginx.go
+++ b/baras/nginx.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
+	"regexp"
 )
 
 var _ = Describe("nginx config logic", func() {
@@ -26,6 +27,13 @@ var _ = Describe("nginx config logic", func() {
 		It("returns 422 Unprocessable Entity", func() {
 			session := cf.Cf("curl", "-X", "POST", "/v3/droplets/literally-any-guid/upload?bits_path='some/path'", "-i")
 			Eventually(session).Should(Say("422"))
+		})
+	})
+
+	Describe("Response headers", func() {
+		It("does not contain 'Server: nginx'", func() {
+			session := cf.Cf("curl", "/v3/info/usage_summary", "-i")
+			Eventually(session).ShouldNot(Say(regexp.QuoteMeta("Server: nginx") + `\/?\d+(\.\d+){0,2}`))
 		})
 	})
 })


### PR DESCRIPTION
With capi-release [PR](https://github.com/cloudfoundry/capi-release/pull/406)  the server name will not be any more present in response headers. This PR adds a test to check the server name is not present in the response header.