### PR TITLE
add default `buildpack` lifecycle

### DIFF
--- a/baras/manifest.go
+++ b/baras/manifest.go
@@ -171,6 +171,7 @@ applications:
 - name: %s
   buildpacks:
   - %s
+  lifecycle: buildpack
   env:
     foo: qux
     snack: walnuts


### PR DESCRIPTION
Related https://github.com/cloudfoundry/cloud_controller_ng/pull/3778