### PR TITLE
Add label "v2_api" to v2-only test

### DIFF
--- a/baras/deployments.go
+++ b/baras/deployments.go
@@ -74,7 +74,7 @@ var _ = Describe("deployments", func() {
 	})
 
 	// TODO: delete me once we delete v2
-	Describe("Creating new processes on the same app", func() {
+	Describe("Creating new processes on the same app", Label("v2_api"), func() {
 		It("ignores older processes on the same app", func() {
 			deploymentGuid := CreateDeployment(appGUID, "rolling", 1)
 			Expect(deploymentGuid).ToNot(BeEmpty())


### PR DESCRIPTION
* allows for easy filtering of that test on v2-disabled CF installations
* see Concourse run-baras job PR: https://github.com/cloudfoundry/capi-ci/pull/117

Part of the v2 deprecation story: https://github.com/cloudfoundry/community/issues/1001