### PR TITLE
Remove v2 API leftovers

### DIFF
--- a/baras/manifest.go
+++ b/baras/manifest.go
@@ -344,18 +344,6 @@ applications:
 						target := cf.Cf("target", "-o", apps[0].orgName, "-s", spaceName).Wait()
 						Expect(target).To(Exit(0), "failed targeting")
 
-						appEndpoint := fmt.Sprintf("/v2/apps/%s", appGUID)
-						extraPortsJSON, err := json.Marshal(
-							struct {
-								Ports []int `json:"ports"`
-							}{
-								[]int{8080, 8081, 8082},
-							},
-						)
-						Expect(err).NotTo(HaveOccurred())
-						session := cf.Cf("curl", appEndpoint, "-X", "PUT", "-d", string(extraPortsJSON))
-						Eventually(session).Should(Exit(0))
-
 						appRoutePrefix := random_name.BARARandomName("ROUTE")
 						sidecarRoutePrefix1 := random_name.BARARandomName("ROUTE")
 						sidecarRoutePrefix2 := random_name.BARARandomName("ROUTE")
@@ -364,7 +352,7 @@ applications:
 						CreateAndMapRouteWithPort(appGUID, spaceGUID, domainGUID, sidecarRoutePrefix1, 8081)
 						CreateAndMapRouteWithPort(appGUID, spaceGUID, domainGUID, sidecarRoutePrefix2, 8082)
 
-						session = cf.Cf("start", apps[0].name)
+						session = cf.Cf("restart", apps[0].name)
 						Eventually(session).Should(Exit(0))
 
 						Eventually(func() *Session {

--- a/baras/sidecars.go
+++ b/baras/sidecars.go
@@ -1,7 +1,6 @@
 package baras
 
 import (
-	"encoding/json"
 	"fmt"
 
 	. "github.com/cloudfoundry/capi-bara-tests/bara_suite_helpers"
@@ -52,18 +51,6 @@ var _ = Describe("sidecars", func() {
 			CreateSidecar("my_sidecar1", []string{"web"}, fmt.Sprintf("WHAT_AM_I=LEFT_SIDECAR bundle exec rackup config.ru -o 0.0.0.0 -p %d", 8081), 50, appGUID)
 			CreateSidecar("my_sidecar2", []string{"web"}, fmt.Sprintf("WHAT_AM_I=RIGHT_SIDECAR bundle exec rackup config.ru -o 0.0.0.0 -p %d", 8082), 100, appGUID)
 
-			appEndpoint := fmt.Sprintf("/v2/apps/%s", appGUID)
-			extraPortsJSON, err := json.Marshal(
-				struct {
-					Ports []int `json:"ports"`
-				}{
-					[]int{8080, 8081, 8082},
-				},
-			)
-			Expect(err).NotTo(HaveOccurred())
-			session := cf.Cf("curl", appEndpoint, "-X", "PUT", "-d", string(extraPortsJSON))
-			Eventually(session).Should(Exit(0))
-
 			appRoutePrefix = random_name.BARARandomName("ROUTE")
 			sidecarRoutePrefix1 = random_name.BARARandomName("ROUTE")
 			sidecarRoutePrefix2 = random_name.BARARandomName("ROUTE")
@@ -71,8 +58,6 @@ var _ = Describe("sidecars", func() {
 			CreateAndMapRouteWithPort(appGUID, spaceGUID, domainGUID, appRoutePrefix, 8080)
 			CreateAndMapRouteWithPort(appGUID, spaceGUID, domainGUID, sidecarRoutePrefix1, 8081)
 			CreateAndMapRouteWithPort(appGUID, spaceGUID, domainGUID, sidecarRoutePrefix2, 8082)
-
-			Eventually(session).Should(Exit(0))
 		})
 
 		Context("and the app and sidecar are listening on different ports", func() {

--- a/helpers/app_helpers/app_droplet.go
+++ b/helpers/app_helpers/app_droplet.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cloudfoundry/capi-bara-tests/helpers/config"
+	"github.com/cloudfoundry/capi-bara-tests/helpers/v3_helpers"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 	"github.com/cloudfoundry/cf-test-helpers/v2/helpers"
-	"github.com/cloudfoundry/capi-bara-tests/helpers/config"
-	"github.com/cloudfoundry/capi-bara-tests/helpers/download"
-	"github.com/cloudfoundry/capi-bara-tests/helpers/v3_helpers"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
@@ -59,14 +58,6 @@ func (droplet *AppDroplet) Create() error {
 
 	droplet.GUID = guidGrabber.GUID
 	return nil
-}
-
-func (droplet *AppDroplet) DownloadTo(downloadPath string) (string, error) {
-	dropletTarballPath := fmt.Sprintf("%s.tar.gz", downloadPath)
-	downloadURL := fmt.Sprintf("/v2/apps/%s/droplet/download", droplet.AppGUID)
-
-	err := download.WithRedirect(downloadURL, dropletTarballPath, droplet.Config)
-	return dropletTarballPath, err
 }
 
 func (droplet *AppDroplet) UploadFrom(uploadPath string) {


### PR DESCRIPTION
* remove POSTs to /v2/apps for configuring the application ports
* ports are configured when mapping routes, but note that an app restart is required
* func DownloadTo is nowhere used, removing